### PR TITLE
Changes the type of foreignAssets from List<long> to List<ulong>

### DIFF
--- a/dotnet-algorand-sdk/Transaction.cs
+++ b/dotnet-algorand-sdk/Transaction.cs
@@ -191,7 +191,7 @@ namespace Algorand
         public List<long> foreignApps = new List<long>();
 
         [JsonProperty(PropertyName = "apas")]
-        public List<long> foreignAssets = new List<long>();
+        public List<ulong> foreignAssets = new List<ulong>();
 
         [JsonProperty(PropertyName = "apgs")]
         public StateSchema globalStateSchema = new StateSchema();
@@ -487,7 +487,7 @@ namespace Algorand
                             Address assetCloseTo, Address freezeTarget, ulong? assetFreezeID, bool freezeState,
                             // application fields
                             List<byte[]> applicationArgs, OnCompletion onCompletion, TEALProgram approvalProgram, List<Address> accounts,
-                            List<long> foreignApps, List<long> foreignAssets, StateSchema globalStateSchema, ulong? applicationId,
+                            List<long> foreignApps, List<ulong> foreignAssets, StateSchema globalStateSchema, ulong? applicationId,
                             StateSchema localStateSchema, TEALProgram clearStateProgram)
         {
             this.type = type;

--- a/dotnet-algorand-sdk/Util/Encoder.cs
+++ b/dotnet-algorand-sdk/Util/Encoder.cs
@@ -267,7 +267,7 @@ namespace Algorand
                         return !(trans.applicationArgs is null || trans.applicationArgs.Count < 1);
                     };
                 }
-                else if (property.PropertyType == typeof(List<long>) && property.PropertyName == "apas")
+                else if (property.PropertyType == typeof(List<ulong>) && property.PropertyName == "apas")
                 {
                     property.ShouldSerialize = instance => {
                         var trans = instance as Transaction;


### PR DESCRIPTION
Changes the type of foreignAssets from List<long> to List<ulong>. This fixes an error when calculating the group ID for transaction groups containing an Application Call tx w/ a populated foreignAssets field.

Signed values are packed differently than unsigned values, so according to the network, the group ID on each transaction in the groups is incorrect, causing the transactions to be rejected.

According to the docs (https://developer.algorand.org/docs/reference/transactions/#application-call-transaction) the Foreign Assets field should be an `Address` type, which I believe is incorrect. Instead, the TEAL spec (https://developer.algorand.org/docs/reference/teal/specification/) lists the Assets field as `uint64`, and describes it as a list. 

NOTE: I believe this same issue exists with the foreignApps field in the Transaction class, however I currently don't have a straightforward way to verify that claim. In fact, most usages of `long` could probably be changed to `ulong` as `int64` doesn't appear in the TEAL spec or Transaction reference.