### PR TITLE
fix asa creation

### DIFF
--- a/dotnet-algorand-sdk/Transaction.cs
+++ b/dotnet-algorand-sdk/Transaction.cs
@@ -1171,7 +1171,7 @@ namespace Algorand
 
                 if (url != null)
                 {
-                    if (url.Length > 32) throw new ArgumentException("asset url cannot be greater than 32 characters");
+                    if (url.Length > 96) throw new ArgumentException("asset url cannot be greater than 96 characters");
                     this.url = url;
                 }
 
@@ -1180,7 +1180,7 @@ namespace Algorand
                     if (metadataHash.Length > 32) throw new ArgumentException("asset metadataHash cannot be greater than 32 bytes");
                     try
                     {
-                        Convert.FromBase64String(Encoding.UTF8.GetString(metadataHash));
+                        //Convert.FromBase64String(Encoding.UTF8.GetString(metadataHash));
                     }
                     catch (Exception)
                     {


### PR DESCRIPTION
at hackathon in Zurich with Rayen we found out that there is bug in asa creation in .net library. according to nft standard arc0003 the url must be approx 60 char long.. it has been increased recently to 96.

also there was issue with the hash of the data. 32 bytes are not base64 encoded