### PR TITLE
Add fallback for base64 string while reading bytes

### DIFF
--- a/dotnet-algorand-sdk/Util/JsonConverters.cs
+++ b/dotnet-algorand-sdk/Util/JsonConverters.cs
@@ -22,7 +22,25 @@ namespace Algorand
         {
             if (objectType == typeof(Address))
             {
-                var bytes = (byte[])reader.Value;
+                byte[] bytes;
+
+                switch (reader.Value)
+                {
+                    case byte[] b:
+                    {
+                        bytes = b;
+                        break;
+                    }
+                    case string s:
+                    {
+                        bytes = Convert.FromBase64String(s);
+                        break;
+                    }
+                    default:
+                        bytes = null;
+                        break;
+                }
+                
                 if (bytes != null && bytes.Length > 0) return new Address(bytes);
                 else return new Address();
             } else


### PR DESCRIPTION
For some transactions node responds with base64 string type for addresses.