### PR TITLE
use default token header

### DIFF
--- a/dotnet-algorand-sdk/V2/HttpClientConfigurator.cs
+++ b/dotnet-algorand-sdk/V2/HttpClientConfigurator.cs
@@ -12,9 +12,18 @@ namespace Algorand.V2
         {
             var _httpClient = new HttpClient();
 
-            if (host.Contains("algorand.api.purestake.io") || host.Contains("bsngate.com/api"))
-                tokenHeader = "X-API-Key";
-
+            if (string.IsNullOrEmpty(tokenHeader))
+            {
+                if (host.Contains("algorand.api.purestake.io") || host.Contains("bsngate.com/api"))
+                {
+                    tokenHeader = "X-API-Key";
+                }
+                else
+                {
+                    tokenHeader = "X-Algo-API-Token";
+                }
+            }
+            
             if (tokenHeader != null && tokenHeader.Length > 0)
                 _httpClient.DefaultRequestHeaders.Add(tokenHeader, token);
 


### PR DESCRIPTION
when one does not provide header, use the default X-Algo-API-Token

do not try to rewrite tokenHeader even for purestake if tokenHeader is defined